### PR TITLE
infer_workspace: treat blank workspace as unset

### DIFF
--- a/R/workspace.R
+++ b/R/workspace.R
@@ -93,13 +93,13 @@ find_workspace <- function(gf, name, description=NULL, create=FALSE) {
 #' @export
 infer_workspace <- function(gf, workspace=NULL, workspace_name=NULL,
                             create_workspace=FALSE, workspace_description=NULL) {
-  if(!is.null(workspace)) {
+  if(!is.null(default_if_null(workspace, NULL))) {
     return(workspace)
-  } else if(!is.null(workspace_name)) {
+  } else if(!is.null(default_if_null(workspace_name, NULL))) {
     return(find_workspace(gf, workspace_name,
                           description=workspace_description,
                           create=create_workspace)$api_id)
-  } else if(!is.null(gf$workspace)) {
+  } else if(!is.null(default_if_null(gf$workspace, NULL))) {
     return(gf$workspace)
   }
 

--- a/tests/testthat/test_unit.R
+++ b/tests/testthat/test_unit.R
@@ -516,6 +516,25 @@ test_that("infer_workspace auto-selects the single accessible workspace (scoped 
   expect_equal(infer_workspace(gf), "only-id")
 })
 
+test_that("infer_workspace treats a blank client workspace as unset (scoped key)", {
+  # read_config()/gofigr_client() normalize a missing workspace to "" rather
+  # than NULL, so an empty string must fall through to the scoped-key fallback
+  # instead of being returned as the workspace id (which produced workspace//).
+  local_mocked_bindings(
+    list_workspaces = function(gf) list(list(api_id = "only-id", name = "Only"))
+  )
+  gf <- list(workspace = "")
+  expect_equal(infer_workspace(gf), "only-id")
+})
+
+test_that("infer_workspace ignores blank workspace/workspace_name arguments", {
+  local_mocked_bindings(
+    list_workspaces = function(gf) list(list(api_id = "only-id", name = "Only"))
+  )
+  gf <- list(workspace = "")
+  expect_equal(infer_workspace(gf, workspace = "", workspace_name = ""), "only-id")
+})
+
 test_that("infer_workspace errors when no workspaces are accessible", {
   local_mocked_bindings(
     list_workspaces = function(gf) list()


### PR DESCRIPTION
A scoped API key (e.g. on compute instances) leaves the client workspace blank, and read_config()/gofigr_client() normalize a missing workspace to "" rather than NULL. infer_workspace() guarded on !is.null(), so the empty string was returned verbatim and produced requests to workspace// (404), making the scoped-key singleton fallback unreachable.

Route the workspace, workspace_name, and gf$workspace guards through default_if_null(x, NULL) so blanks fall through to the fallback. Add regression tests for the empty-string client default and blank arguments.